### PR TITLE
Fixes/resource links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,20 +1,18 @@
 # Site settings
-title: Your awesome title
-email: your-email@domain.com
+title: Days in Life
+email: ridwan.arefin@gmail.com
 description: > # this means to ignore newlines until "baseurl:"
-  Write an awesome description for your new site here. You can edit this
-  line in _config.yml. It will appear in your document head meta (for
-  Google search results) and in your feed.xml site description.
-baseurl: "" # the subpath of your site, e.g. /blog/
-url: "http://yourdomain.com" # the base hostname & protocol for your site
-twitter_username: jekyllrb
-github_username:  jekyll
+  Kazi Ridwan's blog.
+baseurl: "/blog/" # the subpath of your site, e.g. /blog/
+url: "https://kaziridwan.github.io" # the base hostname & protocol for your site
+twitter_username: ridwanshere
+github_username:  kaziridwan
 
 # Build settings
 markdown: kramdown
 
 paginate: 4
 
-author: Your name
+author: Ridwan
 
 gems: [jekyll-paginate]

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -2,8 +2,8 @@
   <title>{{ site.title }}</title>
 	<meta charset="utf-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1" />
-	<!--[if lte IE 8]><script src="js/ie/html5shiv.js"></script><![endif]-->
+	<!--[if lte IE 8]><script src="{{ site.baseurl }}js/ie/html5shiv.js"></script><![endif]-->
 	<link rel="stylesheet" href={{ site.baseurl }}"css/main.css" />
-	<!--[if lte IE 9]><link rel="stylesheet" href="assets/css/ie9.css" /><![endif]-->
-	<!--[if lte IE 8]><link rel="stylesheet" href="assets/css/ie8.css" /><![endif]-->
+	<!--[if lte IE 9]><link rel="stylesheet" href="{{ site.baseurl }}assets/css/ie9.css" /><![endif]-->
+	<!--[if lte IE 8]><link rel="stylesheet" href="{{ site.baseurl }}assets/css/ie8.css" /><![endif]-->
 </head>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -3,7 +3,7 @@
 	<meta charset="utf-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1" />
 	<!--[if lte IE 8]><script src="js/ie/html5shiv.js"></script><![endif]-->
-	<link rel="stylesheet" href="/css/main.css" />
+	<link rel="stylesheet" href={{ site.baseurl }}"css/main.css" />
 	<!--[if lte IE 9]><link rel="stylesheet" href="assets/css/ie9.css" /><![endif]-->
 	<!--[if lte IE 8]><link rel="stylesheet" href="assets/css/ie8.css" /><![endif]-->
 </head>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -3,7 +3,7 @@
 	<meta charset="utf-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1" />
 	<!--[if lte IE 8]><script src="{{ site.baseurl }}js/ie/html5shiv.js"></script><![endif]-->
-	<link rel="stylesheet" href={{ site.baseurl }}"css/main.css" />
+	<link rel="stylesheet" href="{{ site.baseurl }}css/main.css" />
 	<!--[if lte IE 9]><link rel="stylesheet" href="{{ site.baseurl }}assets/css/ie9.css" /><![endif]-->
 	<!--[if lte IE 8]><link rel="stylesheet" href="{{ site.baseurl }}assets/css/ie8.css" /><![endif]-->
 </head>

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,5 +1,5 @@
-<script src="/js/jquery.min.js"></script>
-<script src="/js/skel.min.js"></script>
-<script src="/js/util.js"></script>
-<!--[if lte IE 8]><script src="assets/js/ie/respond.min.js"></script><![endif]-->
-<script src="/js/main.js"></script>
+<script src="{{ site.baseurl }}js/jquery.min.js"></script>
+<script src="{{ site.baseurl }}js/skel.min.js"></script>
+<script src="{{ site.baseurl }}js/util.js"></script>
+<!--[if lte IE 8]><script src="{{ site.baseurl }}assets/js/ie/respond.min.js"></script><![endif]-->
+<script src="{{ site.baseurl }}js/main.js"></script>


### PR DESCRIPTION
the css and js links have been prefixed by "site.baseurl"

this makes the blog easier to be created on subdirectories such as http://something.com/blog , rather than the root directory itself, as in http://something.com.

Otherwise, the css and js files were linked inappropriately, if hosted on a subdirectory
