### PR TITLE
Fix asset paths

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,9 +1,9 @@
 <head>
   <title>{{ site.title }}</title>
-	<meta charset="utf-8" />
-	<meta name="viewport" content="width=device-width, initial-scale=1" />
-	<!--[if lte IE 8]><script src="{{ site.baseurl }}js/ie/html5shiv.js"></script><![endif]-->
-	<link rel="stylesheet" href="{{ site.baseurl }}css/main.css" />
-	<!--[if lte IE 9]><link rel="stylesheet" href="{{ site.baseurl }}assets/css/ie9.css" /><![endif]-->
-	<!--[if lte IE 8]><link rel="stylesheet" href="{{ site.baseurl }}assets/css/ie8.css" /><![endif]-->
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <!--[if lte IE 8]><script src="{{ "js/ie/html5shiv.js" | prepend: site.baseurl }}"></script><![endif]-->
+  <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
+  <!--[if lte IE 9]><link rel="stylesheet" href="{{ "assets/css/ie9.css" | prepend: site.baseurl }}" /><![endif]-->
+  <!--[if lte IE 8]><link rel="stylesheet" href="{{ "assets/css/ie8.css" | prepend: site.baseurl }}" /><![endif]-->
 </head>

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,5 +1,5 @@
-<script src="{{ site.baseurl }}js/jquery.min.js"></script>
-<script src="{{ site.baseurl }}js/skel.min.js"></script>
-<script src="{{ site.baseurl }}js/util.js"></script>
-<!--[if lte IE 8]><script src="{{ site.baseurl }}assets/js/ie/respond.min.js"></script><![endif]-->
-<script src="{{ site.baseurl }}js/main.js"></script>
+<script src="{{ "/js/jquery.min.js" | prepend: site.baseurl }}"></script>
+<script src="{{ "/js/skel.min.js" | prepend: site.baseurl }}"></script>
+<script src="{{ "/js/util.js" | prepend: site.baseurl }}"></script>
+<!--[if lte IE 8]><script src="{{ "/assets/js/ie/respond.min.js" | prepend: site.baseurl }}"></script><![endif]-->
+<script src="{{ "/js/main.js" | prepend: site.baseurl }}"></script>


### PR DESCRIPTION
When you go to any other page, the CSS and JS paths are incorrect, as you can see in this image:

![screen shot 2015-12-31 at 9 13 27 am](https://cloud.githubusercontent.com/assets/5678694/12065157/51cd095a-afa0-11e5-9897-038b689cc0c2.png)

This pull request fixes the paths to the CSS and JS assets for every page. Here is an image after the file changes:

![screen shot 2015-12-31 at 10 55 17 am](https://cloud.githubusercontent.com/assets/5678694/12065891/ffd0726a-afac-11e5-842c-258b40cee1c5.png)
